### PR TITLE
⬆️ Update object-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "busboy": "^0.3.1",
     "fs-capacitor": "^2.0.4",
     "http-errors": "^1.7.3",
-    "object-path": "^0.11.4"
+    "object-path": "^0.11.8"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.3",


### PR DESCRIPTION
We have recently discovered a vulnerability in versions of `object-path` <= 0.11.5 .  This commit updates `object-path` to the most recent version

This commit does not change behavior