### PR TITLE
Specify version range for @types/fs-capacitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@types/express": "*",
-    "@types/fs-capacitor": "*",
+    "@types/fs-capacitor": "^2.0.0",
     "@types/koa": "*",
     "busboy": "^0.3.1",
     "fs-capacitor": "^2.0.4",


### PR DESCRIPTION
The types have been removed from DefinitelyTyped in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62785

Version 8.0.0 is the stub package, and version 2.0.0 is the only other version that exists, so pinning this version should not mess up any dependency tree and just fix the type problem.